### PR TITLE
docs: add env example template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+DATABASE_URL=
+WEB_ORIGIN=http://localhost:5173
+PORT=4000
+NODE_ENV=development
+
+# JWT / Cookies
+JWT_SECRET=
+REFRESH_SECRET=
+REFRESH_COOKIE_NAME=basils_r
+
+# Mail
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASS=
+MAIL_FROM="BASILS Auth <no-reply@basils.example>"
+
+# Crypto (base64 32 bytes for AES-256-GCM)
+ENCRYPTION_KEY=


### PR DESCRIPTION
## Summary
- add example environment configuration template for local development

## Testing
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68a959d6cf48832cbe8fbfef73cadf88