### PR TITLE
Add ESM package.json for authenticator API

### DIFF
--- a/authenticator_api/package.json
+++ b/authenticator_api/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "authenticator_api",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "engines": { "node": ">=22" },
+  "scripts": {
+    "dev": "nodemon src/server.js",
+    "start": "node src/server.js",
+    "lint": "eslint .",
+    "format": "prettier --write .",
+    "migrate": "sequelize db:migrate",
+    "migrate:undo": "sequelize db:migrate:undo",
+    "seed": "sequelize db:seed:all",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "bcryptjs": "latest",
+    "cookie-parser": "latest",
+    "cors": "latest",
+    "dotenv": "latest",
+    "express": "latest",
+    "helmet": "latest",
+    "jsonwebtoken": "latest",
+    "nodemailer": "latest",
+    "pino": "latest",
+    "qrcode": "latest",
+    "rate-limiter-flexible": "latest",
+    "sequelize": "latest",
+    "pg": "latest",
+    "pg-hstore": "latest",
+    "speakeasy": "latest",
+    "uuid": "latest",
+    "zod": "latest"
+  },
+  "devDependencies": {
+    "eslint": "latest",
+    "eslint-config-standard": "latest",
+    "eslint-plugin-import": "latest",
+    "eslint-plugin-n": "latest",
+    "nodemon": "latest",
+    "prettier": "latest",
+    "sequelize-cli": "latest"
+  }
+}


### PR DESCRIPTION
## Summary
- add ESM-configured package.json with Sequelize and related tooling for authenticator API
- include placeholder test script to clarify lack of automated tests

## Testing
- `npm test` (fails: Error: no test specified)
- `cd authenticator_api && npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68a9a1c51c08832c86c5b5e4557be2ee