### PR TITLE
chore: add sequelize cli configuration

### DIFF
--- a/.sequelizerc
+++ b/.sequelizerc
@@ -1,0 +1,7 @@
+const path = require('path')
+module.exports = {
+  'config': path.resolve('src', 'db', 'config.cjs'),
+  'models-path': path.resolve('src', 'models'),
+  'seeders-path': path.resolve('src', 'seeders'),
+  'migrations-path': path.resolve('src', 'migrations')
+}

--- a/src/db/config.cjs
+++ b/src/db/config.cjs
@@ -1,0 +1,15 @@
+require('dotenv/config')
+const { URL } = require('url')
+const dbUrl = new URL(process.env.DATABASE_URL || 'postgres://localhost:5432/app')
+
+const common = {
+  dialect: 'postgres',
+  url: dbUrl.toString(),
+  logging: false
+}
+
+module.exports = {
+  development: common,
+  test: common,
+  production: common
+}


### PR DESCRIPTION
## Summary
- configure Sequelize CLI paths
- add database URL config for Sequelize environments

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a79b7a4c832cb41ca608257e74c5