### PR TITLE
feat: add sequelize models and associations

### DIFF
--- a/src/models/PasswordResetToken.js
+++ b/src/models/PasswordResetToken.js
@@ -1,0 +1,10 @@
+import { DataTypes, Model } from 'sequelize'
+import sequelize from '../db/index.js'
+export default class PasswordResetToken extends Model {}
+PasswordResetToken.init({
+  id: { type: DataTypes.STRING, primaryKey: true },
+  userId: { type: DataTypes.STRING, allowNull: false },
+  tokenHash: { type: DataTypes.STRING, unique: true, allowNull: false },
+  expiresAt: { type: DataTypes.DATE, allowNull: false },
+  createdAt: { type: DataTypes.DATE, allowNull: false, defaultValue: DataTypes.NOW }
+}, { sequelize, modelName: 'PasswordResetToken', tableName: 'PasswordResetTokens', timestamps: false })

--- a/src/models/Session.js
+++ b/src/models/Session.js
@@ -1,0 +1,12 @@
+import { DataTypes, Model } from 'sequelize'
+import sequelize from '../db/index.js'
+export default class Session extends Model {}
+Session.init({
+  id: { type: DataTypes.STRING, primaryKey: true },
+  userId: { type: DataTypes.STRING, allowNull: false },
+  refreshTokenHash: { type: DataTypes.STRING, allowNull: false },
+  userAgent: { type: DataTypes.STRING },
+  ip: { type: DataTypes.STRING },
+  expiresAt: { type: DataTypes.DATE, allowNull: false },
+  createdAt: { type: DataTypes.DATE, allowNull: false, defaultValue: DataTypes.NOW }
+}, { sequelize, modelName: 'Session', tableName: 'Sessions', timestamps: false })

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -1,0 +1,14 @@
+import { DataTypes, Model } from 'sequelize'
+import sequelize from '../db/index.js'
+export default class User extends Model {}
+User.init({
+  id: { type: DataTypes.STRING, primaryKey: true },
+  email: { type: DataTypes.STRING, unique: true, allowNull: false },
+  passwordHash: { type: DataTypes.STRING },
+  emailVerified: { type: DataTypes.DATE },
+  totpEnabled: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+  totpSecretEnc: { type: DataTypes.TEXT },
+  role: { type: DataTypes.ENUM('ADMIN', 'STAFF'), allowNull: false, defaultValue: 'STAFF' },
+  createdAt: { type: DataTypes.DATE, allowNull: false, defaultValue: DataTypes.NOW },
+  updatedAt: { type: DataTypes.DATE, allowNull: false, defaultValue: DataTypes.NOW }
+}, { sequelize, modelName: 'User', tableName: 'Users', timestamps: true, updatedAt: 'updatedAt', createdAt: 'createdAt' })

--- a/src/models/VerificationToken.js
+++ b/src/models/VerificationToken.js
@@ -1,0 +1,10 @@
+import { DataTypes, Model } from 'sequelize'
+import sequelize from '../db/index.js'
+export default class VerificationToken extends Model {}
+VerificationToken.init({
+  id: { type: DataTypes.STRING, primaryKey: true },
+  userId: { type: DataTypes.STRING, allowNull: false },
+  tokenHash: { type: DataTypes.STRING, unique: true, allowNull: false },
+  expiresAt: { type: DataTypes.DATE, allowNull: false },
+  createdAt: { type: DataTypes.DATE, allowNull: false, defaultValue: DataTypes.NOW }
+}, { sequelize, modelName: 'VerificationToken', tableName: 'VerificationTokens', timestamps: false })

--- a/src/models/associations.js
+++ b/src/models/associations.js
@@ -1,0 +1,15 @@
+import User from './User.js'
+import Session from './Session.js'
+import VerificationToken from './VerificationToken.js'
+import PasswordResetToken from './PasswordResetToken.js'
+
+User.hasMany(Session, { foreignKey: 'userId' })
+Session.belongsTo(User, { foreignKey: 'userId' })
+
+User.hasMany(VerificationToken, { foreignKey: 'userId' })
+VerificationToken.belongsTo(User, { foreignKey: 'userId' })
+
+User.hasMany(PasswordResetToken, { foreignKey: 'userId' })
+PasswordResetToken.belongsTo(User, { foreignKey: 'userId' })
+
+export { User, Session, VerificationToken, PasswordResetToken }


### PR DESCRIPTION
## Summary
- add User, Session, VerificationToken, and PasswordResetToken Sequelize models
- wire up model relationships in a central associations file

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a9c38764832c99a90dcfdd1a6faa