### PR TITLE
feat: add winston logger

### DIFF
--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,0 +1,28 @@
+import winston from 'winston'
+
+const isDev = process.env.NODE_ENV === 'development'
+
+const consoleFormat = winston.format.combine(
+  winston.format.colorize({ all: true }),
+  winston.format.timestamp({ format: 'MMM-DD-YYYY HH:mm:ss' }),
+  winston.format.printf(info => `${info.timestamp} [${info.level}]: ${info.message}`)
+)
+
+const jsonFormat = winston.format.combine(
+  winston.format.timestamp(),
+  winston.format.errors({ stack: true }),
+  winston.format.json()
+)
+
+const logger = winston.createLogger({
+  level: isDev ? 'debug' : 'info',
+  format: isDev ? consoleFormat : jsonFormat,
+  transports: [
+    new winston.transports.Console({
+      format: isDev ? consoleFormat : jsonFormat
+    })
+  ],
+  exitOnError: false
+})
+
+export default logger


### PR DESCRIPTION
## Summary
- add Winston logger with environment-aware formatting

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c8129fcc832c85ae86a1a692a5de