### PR TITLE
feat: add winston error handler

### DIFF
--- a/src/middleware/error.js
+++ b/src/middleware/error.js
@@ -1,0 +1,14 @@
+import logger from '../lib/logger.js'
+
+export default function errorHandler (err, req, res, next) {
+  if (err?.name === 'ZodError') {
+    return res.status(400).json({ error: 'Invalid input', issues: err.issues })
+  }
+  const status = err.status || 500
+  if (status >= 500) {
+    logger.error(`${req.method} ${req.originalUrl} -> ${status}: ${err.stack || err.message}`)
+  } else {
+    logger.warn(`${req.method} ${req.originalUrl} -> ${status}: ${err.message}`)
+  }
+  return res.status(status).json({ error: status === 500 ? 'Something went wrong' : err.message })
+}


### PR DESCRIPTION
## Summary
- log server errors and warnings with winston

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aa93212834832cabff3a35b51246f7