### PR TITLE
Add Zod validation schemas for authentication flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "mysql2": "^3.11.3",
     "nodemon": "^3.1.7",
     "winston": "latest",
-    "winston-transport": "latest"
+    "winston-transport": "latest",
+    "zod": "latest"
   }
 }

--- a/src/validators/authSchemas.js
+++ b/src/validators/authSchemas.js
@@ -1,0 +1,35 @@
+import { z } from 'zod'
+
+export const signupSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+  acceptTerms: z.boolean()
+})
+
+export const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1)
+})
+
+export const twoFaVerifySchema = z.object({
+  code: z.string().length(6),
+  tempToken: z.string()
+})
+
+export const twoFaEnableSchema = z.object({
+  code: z.string().length(6),
+  secret: z.string()
+})
+
+export const emailTokenSchema = z.object({
+  token: z.string().min(1)
+})
+
+export const forgotSchema = z.object({
+  email: z.string().email()
+})
+
+export const resetSchema = z.object({
+  token: z.string(),
+  newPassword: z.string().min(8)
+})


### PR DESCRIPTION
## Summary
- add Zod-based schemas for signup, login, two-factor auth, email tokens, forgot password, and reset flows
- include zod dependency

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/winston)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aa96943238832c9d0ade56f6671e16