### PR TITLE
Add server bootstrap with Express

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,26 @@
+import 'dotenv/config'
+import express from 'express'
+import helmet from 'helmet'
+import cors from 'cors'
+import cookieParser from 'cookie-parser'
+import corsConfig from './config/cors.js'
+import errorHandler from './middleware/error.js'
+import authRouter from './routes/auth.js'
+import { connectDb } from './db/index.js'
+import './models/associations.js'
+
+const app = express()
+app.set('trust proxy', 1)
+app.use(helmet())
+app.use(cors(corsConfig()))
+app.use(express.json({ limit: '1mb' }))
+app.use(cookieParser())
+
+app.get('/api/health', (req, res) => res.json({ ok: true }))
+app.use('/api/auth', authRouter)
+app.use(errorHandler)
+
+const PORT = process.env.PORT || 4000
+connectDb().then(() => {
+  app.listen(PORT, () => console.log(`API listening on :${PORT}`))
+})


### PR DESCRIPTION
## Summary
- set up Express server with security, CORS, auth routes, and DB initialization

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9f882784832c9aeb9fea4b8d98d7