### PR TITLE
docs: add README and HTTP examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# Ticketing System Auth Service
+
+A Node.js authentication service built with Express and Sequelize.
+
+## Requirements
+
+- Node.js >= 22
+- PostgreSQL database
+
+## Setup
+
+1. Copy the example environment file and fill required secrets:
+   ```bash
+   cp .env.example .env
+   ```
+   Set `DATABASE_URL`, `JWT_SECRET`, `REFRESH_SECRET`, `ENCRYPTION_KEY` (base64-encoded 32 bytes) and SMTP settings.
+
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+3. Run database migrations:
+   ```bash
+   npx sequelize db:migrate
+   ```
+
+4. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+## Endpoints
+
+- `GET /api/health` – health check.
+- `POST /api/auth/signup` – register a new user.
+- `POST /api/auth/verify-email` – verify an email token.
+- `POST /api/auth/login` – log in and receive tokens.
+- `POST /api/auth/2fa/setup` – generate a TOTP secret (auth required).
+- `POST /api/auth/2fa/enable` – enable two-factor auth (auth required).
+- `POST /api/auth/2fa/verify` – verify a TOTP code after login.
+- `POST /api/auth/password/forgot` – request a password reset email.
+- `POST /api/auth/password/reset` – reset the password with a token.
+- `POST /api/auth/refresh` – rotate the refresh token.
+- `POST /api/auth/logout` – revoke session and clear cookies.
+- `GET /api/auth/me` – fetch the authenticated user.
+
+## Security
+
+Authentication uses `httpOnly` cookies with `SameSite=Lax` and the `Secure` flag enabled in production.
+

--- a/src/tests/http-examples.md
+++ b/src/tests/http-examples.md
@@ -1,0 +1,82 @@
+# HTTP Examples
+
+## GET /api/health
+```bash
+curl http://localhost:4000/api/health
+```
+
+## POST /api/auth/signup
+```bash
+curl -X POST http://localhost:4000/api/auth/signup \
+  -H "Content-Type: application/json" \
+  -d '{"email":"user@example.com","password":"REPLACE_PASSWORD"}'
+```
+
+## POST /api/auth/verify-email
+```bash
+curl -X POST http://localhost:4000/api/auth/verify-email \
+  -H "Content-Type: application/json" \
+  -d '{"token":"REPLACE_TOKEN"}'
+```
+
+## POST /api/auth/login
+```bash
+curl -X POST http://localhost:4000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"user@example.com","password":"REPLACE_PASSWORD"}'
+```
+
+## POST /api/auth/2fa/setup
+```bash
+curl -X POST http://localhost:4000/api/auth/2fa/setup \
+  -H "Authorization: Bearer REPLACE_TOKEN"
+```
+
+## POST /api/auth/2fa/enable
+```bash
+curl -X POST http://localhost:4000/api/auth/2fa/enable \
+  -H "Authorization: Bearer REPLACE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"code":"123456","secret":"REPLACE_SECRET"}'
+```
+
+## POST /api/auth/2fa/verify
+```bash
+curl -X POST http://localhost:4000/api/auth/2fa/verify \
+  -H "Content-Type: application/json" \
+  -d '{"tempToken":"REPLACE_TOKEN","code":"123456"}'
+```
+
+## POST /api/auth/password/forgot
+```bash
+curl -X POST http://localhost:4000/api/auth/password/forgot \
+  -H "Content-Type: application/json" \
+  -d '{"email":"user@example.com"}'
+```
+
+## POST /api/auth/password/reset
+```bash
+curl -X POST http://localhost:4000/api/auth/password/reset \
+  -H "Content-Type: application/json" \
+  -d '{"token":"REPLACE_TOKEN","newPassword":"REPLACE_PASSWORD"}'
+```
+
+## POST /api/auth/refresh
+```bash
+curl -X POST http://localhost:4000/api/auth/refresh \
+  -H "Cookie: REPLACE_COOKIE"
+```
+
+## POST /api/auth/logout
+```bash
+curl -X POST http://localhost:4000/api/auth/logout \
+  -H "Authorization: Bearer REPLACE_TOKEN" \
+  -H "Cookie: REPLACE_COOKIE"
+```
+
+## GET /api/auth/me
+```bash
+curl http://localhost:4000/api/auth/me \
+  -H "Authorization: Bearer REPLACE_TOKEN"
+```
+


### PR DESCRIPTION
## Summary
- document setup, endpoints, and security in new README
- add curl examples for auth and health endpoints

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa69873c8832cbcdefc88db079cdf